### PR TITLE
Test maintainance: add missed tests and removing xUnit1013 warning (#…

### DIFF
--- a/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/TypeConverterTests.cs
@@ -50,8 +50,8 @@ namespace CommandLine.Tests.Unit.Core
                     new object[] {((long) int.MinValue - 1).ToString(), typeof (int), true, null},
 
                     new object[] {"1", typeof (uint), false, (uint) 1},
-                    new object[] {"0", typeof (uint), false, (uint) 0},
-                    new object[] {"-1", typeof (uint), true, null},
+                   // new object[] {"0", typeof (uint), false, (uint) 0},  //cause warning: Skipping test case with duplicate ID
+                   // new object[] {"-1", typeof (uint), true, null},  //cause warning: Skipping test case with duplicate ID
                     new object[] {uint.MaxValue.ToString(), typeof (uint), false, uint.MaxValue},
                     new object[] {uint.MinValue.ToString(), typeof (uint), false, uint.MinValue},
                     new object[] {((long) uint.MaxValue + 1).ToString(), typeof (uint), true, null},

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using CommandLine.Tests.Fakes;
 using FluentAssertions;
 using Xunit;
+using CommandLine.Text;
 
 namespace CommandLine.Tests.Unit
 {
@@ -326,7 +327,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Explicit_version_request_generates_version_info_screen()
         {
             // Fixture setup
@@ -340,17 +341,12 @@ namespace CommandLine.Tests.Unit
             // Verify outcome
             result.Length.Should().BeGreaterThan(0);
             var lines = result.ToNotEmptyLines().TrimStringArray();
-            lines.Should().HaveCount(x => x == 1);
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-#endif
+            lines.Should().HaveCount(x => x == 1);			
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Implicit_help_screen_in_verb_scenario()
         {
             // Fixture setup
@@ -364,14 +360,8 @@ namespace CommandLine.Tests.Unit
             // Verify outcome
             result.Length.Should().BeGreaterThan(0);
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("No verb selected.");
             lines[4].Should().BeEquivalentTo("add        Add file contents to the index.");
@@ -382,7 +372,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Double_dash_help_dispalys_verbs_index_in_verbs_scenario()
         {
             // Fixture setup
@@ -395,14 +385,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("add        Add file contents to the index.");
             lines[3].Should().BeEquivalentTo("commit     Record changes to the repository.");
             lines[4].Should().BeEquivalentTo("clone      Clone a repository into a new directory.");
@@ -411,7 +395,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Theory]
+        [Theory]
         [InlineData("--version")]
         [InlineData("version")]
         public void Explicit_version_request_generates_version_info_screen_in_verbs_scenario(string command)
@@ -428,16 +412,11 @@ namespace CommandLine.Tests.Unit
             result.Length.Should().BeGreaterThan(0);
             var lines = result.ToNotEmptyLines().TrimStringArray();
             lines.Should().HaveCount(x => x == 1);
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Errors_of_type_MutuallyExclusiveSetError_are_properly_formatted()
         {
             // Fixture setup
@@ -450,14 +429,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Option: 'weburl' is not compatible with: 'ftpurl'.");
             lines[4].Should().BeEquivalentTo("Option: 'ftpurl' is not compatible with: 'weburl'.");
@@ -485,7 +458,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Properly_formatted_help_screen_is_displayed_when_usage_is_defined_in_verb_scenario()
         {
             // Fixture setup
@@ -503,14 +476,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Option 'badoption' is unknown.");
             lines[4].Should().BeEquivalentTo("USAGE:");
@@ -530,7 +497,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-         //[Fact]
+         [Fact]
         public void Properly_formatted_help_screen_is_displayed_when_there_is_a_hidden_verb()
         {
             // Fixture setup
@@ -543,14 +510,8 @@ namespace CommandLine.Tests.Unit
             
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("No verb selected.");
             lines[4].Should().BeEquivalentTo("add        Add file contents to the index.");
@@ -560,7 +521,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Properly_formatted_help_screen_is_displayed_when_there_is_a_hidden_verb_selected_usage_displays_with_hidden_option()
         {
             // Fixture setup
@@ -573,14 +534,8 @@ namespace CommandLine.Tests.Unit
             
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("-f, --force    Allow adding otherwise ignored files.");
             lines[3].Should().BeEquivalentTo("--help         Display this help screen.");
             lines[4].Should().BeEquivalentTo("--version      Display version information.");
@@ -627,7 +582,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Specific_verb_help_screen_should_be_displayed_regardless_other_argument()
         {
             // Fixture setup
@@ -645,14 +600,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("--no-hardlinks    Optimize the cloning process from a repository on a local");
             lines[3].Should().BeEquivalentTo("filesystem by copying files.");
             lines[4].Should().BeEquivalentTo("-q, --quiet       Suppress summary message.");
@@ -701,7 +650,7 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Properly_formatted_help_screen_excludes_help_as_unknown_option()
         {
             // Fixture setup
@@ -719,14 +668,8 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             var lines = result.ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Option 'bad-arg' is unknown.");
             lines[4].Should().BeEquivalentTo("--no-hardlinks    Optimize the cloning process from a repository on a local");

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -77,7 +77,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Create_instance_with_enum_options_enabled()
         {
             // Fixture setup
@@ -182,7 +182,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void When_help_text_has_hidden_option_it_should_not_be_added_to_help_text_output()
         {
             // Fixture setup
@@ -307,7 +307,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Options_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -324,14 +324,9 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().StartWithEquivalent("Copyright (c)");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+			
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());			
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
             lines[4].Should().BeEquivalentTo("A sequence option 'i' is defined with fewer or more items than required.");
@@ -343,7 +338,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Verbs_with_specific_verb_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -360,14 +355,8 @@ namespace CommandLine.Tests.Unit.Text
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
 
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().StartWithEquivalent("Copyright (c)");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
             lines[2].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which");
             lines[3].Should().BeEquivalentTo("changes to commit.");
             lines[4].Should().BeEquivalentTo("--amend          Used to amend the tip of the current branch.");
@@ -376,7 +365,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Verbs_with_specific_verb_returns_appropriate_formatted_text_given_display_width_100()
         {
             // Fixture setup
@@ -393,14 +382,8 @@ namespace CommandLine.Tests.Unit.Text
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
 
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().BeEquivalentTo("Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
             lines[2].Should().BeEquivalentTo("-p, --patch      Use the interactive patch selection interface to chose which changes to commit.");
             lines[3].Should().BeEquivalentTo("--amend          Used to amend the tip of the current branch.");
             lines[4].Should().BeEquivalentTo("-m, --message    Use the given message as the commit message.");
@@ -408,7 +391,7 @@ namespace CommandLine.Tests.Unit.Text
             // Teardown
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Verbs_with_unknown_verb_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -425,14 +408,8 @@ namespace CommandLine.Tests.Unit.Text
             // Verify outcome
             var lines = helpText.ToString().ToNotEmptyLines().TrimStringArray();
 
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().StartWithEquivalent("Copyright (c)");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
             lines[2].Should().BeEquivalentTo("add        Add file contents to the index.");
             lines[3].Should().BeEquivalentTo("commit     Record changes to the repository.");
             lines[4].Should().BeEquivalentTo("clone      Clone a repository into a new directory.");
@@ -494,7 +471,7 @@ namespace CommandLine.Tests.Unit.Text
             lines[10].Should().BeEquivalentTo("  mono testapp.exe value");
         }
 
-        //[Fact]
+        [Fact]
         public void Invoke_AutoBuild_for_Options_with_Usage_returns_appropriate_formatted_text()
         {
             // Fixture setup
@@ -510,15 +487,9 @@ namespace CommandLine.Tests.Unit.Text
 
             // Verify outcome
             var text = helpText.ToString();
-            var lines = text.ToNotEmptyLines();
-#if !PLATFORM_DOTNET
-            lines[0].Should().StartWithEquivalent("CommandLine");
-            lines[1].Should().StartWithEquivalent("Copyright (c)");
-#else
-            // Takes the name of the xUnit test program
-            lines[0].Should().StartWithEquivalent("xUnit");
-            lines[1].Should().StartWithEquivalent("Copyright (C) Outercurve Foundation");
-#endif
+            var lines = text.ToNotEmptyLines().TrimStringArray();
+            lines[0].Should().Be(HeadingInfo.Default.ToString());
+            lines[1].Should().Be(CopyrightInfo.Default.ToString());	
             lines[2].Should().BeEquivalentTo("ERROR(S):");
             lines[3].Should().BeEquivalentTo("Token 'badtoken' is not recognized.");
             lines[4].Should().BeEquivalentTo("USAGE:");
@@ -653,5 +624,6 @@ namespace CommandLine.Tests.Unit.Text
 
             Assert.Equal("T" + Environment.NewLine + "e" + Environment.NewLine + "s" + Environment.NewLine + "t", b.ToString());
         }
+        
     }
 }

--- a/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
+++ b/tests/CommandLine.Tests/Unit/UnParserExtensionsTests.cs
@@ -39,7 +39,7 @@ namespace CommandLine.Tests.Unit
         }
 
         [Theory]
-        [MemberData("UnParseDataHidden")]
+        [MemberData(nameof(UnParseDataHidden))]
         public static void Unparsing_hidden_option_returns_command_line(Hidden_Option options, bool showHidden, string result)
         {
             new Parser()


### PR DESCRIPTION
…462)

* Add  test cases ignored in v2.4.3 (18 test case)

* Fix Xunit warning: 'Skipping test case with duplicate ID'

* Fix warning xUnit1014: 'MemberData should use nameof operator to reference member'

* Modify hard-wired copyrigt and heading constants to be platform independent and testsuit independent